### PR TITLE
Fix misspelled Invalid messages

### DIFF
--- a/Go/millionverifier_email_verifier.go
+++ b/Go/millionverifier_email_verifier.go
@@ -54,7 +54,7 @@ func main() {
     case 5:
         fmt.Println("Disposable")
     case 6:
-        fmt.Println("Invlaid")
+        fmt.Println("Invalid")
     }
 
 }

--- a/PHP/millionverifier_email_verifier.php
+++ b/PHP/millionverifier_email_verifier.php
@@ -25,8 +25,8 @@ switch($j->resultcode) {
 	case 5:
 		echo "Disposable";
 		break;
-	case 6:
-		echo "Invlaid";
-		break;
+        case 6:
+                echo "Invalid";
+                break;
 }
 

--- a/Python2/millionverifier_email_verifier.py
+++ b/Python2/millionverifier_email_verifier.py
@@ -27,4 +27,4 @@ elif c == 4:
 elif c == 5:
     print "Disposable"
 elif c == 6:
-    print "Invlaid"
+    print "Invalid"

--- a/Python3/millionverifier_email_verifier.py
+++ b/Python3/millionverifier_email_verifier.py
@@ -27,5 +27,5 @@ elif c == 4:
 elif c == 5:
     print("Disposable")
 elif c == 6:
-    print("Invlaid")
+    print("Invalid")
 


### PR DESCRIPTION
## Summary
- correct `Invalid` message for result code 6 in example scripts

## Testing
- `python3 -m py_compile Python3/millionverifier_email_verifier.py`
- `go build Go/millionverifier_email_verifier.go`